### PR TITLE
gradle dependency bump and Demo debug build variant

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -24,6 +24,14 @@ android {
 
     buildTypes {
         release {
+            resValue "string", "app_name", "PinAuthentication Demo"
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+        debug {
+            applicationIdSuffix ".debug"
+            resValue "string", "app_name", "PinAuthentication Demo Debug"
+            debuggable true
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">Pin Authentication Demo</string>
     <string name="library_name">PinAuthentication Lib Demo</string>
 
     <!-- Settings Fragment -->

--- a/pin-authentication/build.gradle
+++ b/pin-authentication/build.gradle
@@ -78,7 +78,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.6"
 
-    implementation 'com.github.05nelsonm:encrypted-storage:1.0.0'
+    implementation 'com.github.05nelsonm:encrypted-storage:1.0.1'
 
     testImplementation 'junit:junit:4.12'
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"


### PR DESCRIPTION
# Description
<!-- Fixes # (issue) -->
- Bump dependency for `encrypted-storage` to `1.0.1`
- Demo application can now install both release and debug build on devices